### PR TITLE
removing hardcoded vhbbPlotDef.ini

### DIFF
--- a/python/Znunu/paths
+++ b/python/Znunu/paths
@@ -2,13 +2,13 @@
 #!! List of the config you want to use
 #!! The number of config has to be exaclty 7
 #!! The list only support spaces between configs
-List = paths general cuts training datacard plots lhe_weight
+List = paths general cuts training datacard plots lhe_weight samples_nosplit.cfg vhbbPlotDef.ini
 
 [Directories]
 #!! just a variable
-Dname:heppynmore
+Dname:hnm
 #!! Working Directory
-Wdir=/uscms_data/d2/kreis/Hbb/eth/CMSSW_7_4_15/src/
+Wdir=/uscms/home/bortigno/nobackup/vhbb13tev/heppynmore_001_cmssw747/src/
 samplepath = /eos/uscms/store/user/lpchbb/HeppyNtuples/V14
 t3Private = /eos/uscms/store/user/lpchbb/HeppyNtuples/V14/heppynmore/ZprimeZnunuHbb/tmp
 scratch = <!Directories|vhbbpath!>/

--- a/python/controlPlot.py
+++ b/python/controlPlot.py
@@ -26,7 +26,6 @@ if opts.config =="":
 from myutils import BetterConfigParser, printc, ParseInfo, mvainfo, StackMaker, HistoMaker
 
 print opts.config
-opts.config.append('8TeVconfig/vhbbPlotDef.ini')
 config = BetterConfigParser()
 config.read(opts.config)
 TdrStyles.tdrStyle()

--- a/python/manualStack.py
+++ b/python/manualStack.py
@@ -35,7 +35,6 @@ if opts.config =="":
 from myutils import BetterConfigParser, printc, ParseInfo, mvainfo, StackMaker, HistoMaker
 
 print opts.config
-opts.config.append('8TeVconfig/vhbbPlotDef.ini')
 config = BetterConfigParser()
 config.read(opts.config)
 TdrStyles.tdrStyle()

--- a/python/tree_stack.py
+++ b/python/tree_stack.py
@@ -22,7 +22,6 @@ if opts.config =="":
 from myutils import BetterConfigParser, printc, ParseInfo, mvainfo, StackMaker, HistoMaker
 
 print opts.config
-opts.config.append('Znunu/vhbbPlotDef.ini')
 config = BetterConfigParser()
 config.read(opts.config)
 


### PR DESCRIPTION
removed hardcoded vhbbPlotDef.ini. I added the config in the path config. That means that when running using runAll.sh is gonna pick the vhbbPlotDef.ini from the analysis folder. If you are running directly from the python script you need to add this config as option.
